### PR TITLE
feat: add mantra hongbai testnet and rename original

### DIFF
--- a/chains/testnet/mantra-hongbai.json
+++ b/chains/testnet/mantra-hongbai.json
@@ -1,0 +1,18 @@
+{
+    "chain_name": "mantra_hongbai",
+    "api": ["https://api.hongbai.mantrachain.io", "https://rest.testcosmos.directory/mantrachaintestnet"],
+    "rpc": ["https://rpc.hongbai.mantrachain.io"],
+    "snapshot_provider": "",
+    "sdk_version": "0.46.15",
+    "coin_type": "118",
+    "min_tx_fee": "800",
+    "addr_prefix": "uom",
+    "logo": "/logos/mantra.svg",
+    "assets": [{
+        "base": "uom",
+        "symbol": "OM",
+        "exponent": "6",
+        "coingecko_id": "", 
+        "logo": "/logos/mantra.svg"
+    }]
+}

--- a/chains/testnet/mantra-testnet.json
+++ b/chains/testnet/mantra-testnet.json
@@ -1,5 +1,5 @@
 {
-    "chain_name": "mantra",
+    "chain_name": "mantra testnet 1",
     "api": ["https://api.testnet.mantrachain.io:443"],
     "rpc": ["https://rpc.testnet.mantrachain.io/"],
     "snapshot_provider": "",


### PR DESCRIPTION
Hey Ghost this PR will add the new mantra testnet and rename the original so that we have now mantra hongbai and mantra testnet. 

here is another explorer where you can compare values if anything like that is needed

https://explorer.hongbai.mantrachain.io/mantrachain