### PR TITLE
feat: add extra rpc endpoint

### DIFF
--- a/chains/testnet/berachain.json
+++ b/chains/testnet/berachain.json
@@ -1,7 +1,7 @@
 {
     "chain_name": "berachain",
     "api": ["https://berachain-testnet-api.synergynodes.com:443", "https://berachain-testnet.api.l0vd.com:443"],
-    "rpc": ["https://artio.rpc.berachain.com:443"],
+    "rpc": ["https://artio.rpc.berachain.com:443","https://archive-berachain-testnet.whispernode.com/493208d467b1e2083b0023958ab9af944fcad3f8"],
     "snapshot_provider": "",
     "sdk_version": "0.46.15",
     "coin_type": "118",

--- a/chains/testnet/berachain.json
+++ b/chains/testnet/berachain.json
@@ -1,7 +1,7 @@
 {
     "chain_name": "berachain",
-    "api": ["https://berachain-testnet-api.synergynodes.com:443", "https://berachain-testnet.api.l0vd.com:443"],
-    "rpc": ["https://artio.rpc.berachain.com:443","https://archive-berachain-testnet.whispernode.com/493208d467b1e2083b0023958ab9af944fcad3f8"],
+    "api": ["https://berachain-testnet-api.synergynodes.com:443", "https://berachain-testnet.api.l0vd.com:443","https://api-berachain-testnet.whispernode.com:443"],
+    "rpc": ["https://artio.rpc.berachain.com:443","https://archive-berachain-testnet.whispernode.com/493208d467b1e2083b0023958ab9af944fcad3f8:443","https://rpc-berachain-testnet.whispernode.com:443"],
     "snapshot_provider": "",
     "sdk_version": "0.46.15",
     "coin_type": "118",


### PR DESCRIPTION
hey Ghost! this PR will add the extra RPC endpoint, in my local testing it isn't giving any errors so please take a look at the berachain governance tab, if it loads up more than once I think it is safe to assume it is using both endpoints since the community endpoint runs into the rate limit really fast (one to two governance page loads from what I've seen) 